### PR TITLE
Minor API changes

### DIFF
--- a/core/src/main/scala/io/skadi/Context.scala
+++ b/core/src/main/scala/io/skadi/Context.scala
@@ -24,6 +24,6 @@ trait Context
 
 // $COVERAGE-OFF$
 object Context extends Context {
-  val noop: Context = Context
+  val empty: Context = Context
 }
 // $COVERAGE-ON$

--- a/core/src/main/scala/io/skadi/Tracer.scala
+++ b/core/src/main/scala/io/skadi/Tracer.scala
@@ -56,14 +56,14 @@ trait Tracer[F[_]] {
   def trace[A](operationName: String, parent: Span, tags: (String, Tag)*)(fa: F[A]): F[A]
 
   /**
-    * Same as basic `trace` but with explicit parent's context. Usually used on the edge of tracing initialization, once
-    * the [[TraceCarrier]] extracts the [[Context]] from the context carrier
+    * Same as basic `trace` but with explicit optional parent's context. Usually used on the edge of tracing initialization in combination
+    * with [[TraceCarrier]]
     * @param operationName name of span
     * @param parent parent context to use
     * @param tags tags to add to span
     * @param fa operation to trace
     */
-  def trace[A](operationName: String, parent: Context, tags: (String, Tag)*)(fa: F[A]): F[A]
+  def trace[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(fa: F[A]): F[A]
 
   /**
     * Traces evaluation of `fa`. Implementation might use parent span extracted from context of `F[_]` if it exists.
@@ -76,7 +76,7 @@ trait Tracer[F[_]] {
   def traceWith[A](operationName: String, tags: (String, Tag)*)(fa: Span => F[(Span, A)]): F[A]
 
   /**
-    * Same as basic `trace` but with explicit parent set
+    * Same as basic `traceWith` but with explicit parent set
     *
     * @param operationName name of span
     * @param parent parent context to use
@@ -86,15 +86,15 @@ trait Tracer[F[_]] {
   def traceWith[A](operationName: String, parent: Span, tags: (String, Tag)*)(fa: Span => F[(Span, A)]): F[A]
 
   /**
-    * Same as basic `trace` but with explicit parent's context. Usually used on the edge of tracing initialization, once
-    * the [[TraceCarrier]] extracts the [[Context]] from the context carrier
+    * Same as basic `traceWith` but with explicit optional parent's context. Usually used on the edge of tracing initialization in combination
+    * with [[TraceCarrier]]
     *
     * @param operationName name of span
     * @param parent parent context to use
     * @param tags tags to add to span
     * @param fa function that accepts span and returns potentially modified one together with evaluation results
     */
-  def traceWith[A](operationName: String, parent: Context, tags: (String, Tag)*)(
+  def traceWith[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(
       fa: Span => F[(Span, A)]
   ): F[A]
 
@@ -106,13 +106,15 @@ object Tracer {
   def noop[F[_]](implicit F: Functor[F]): Tracer[F] = new Tracer[F] {
     def trace[A](operationName: String, tags: (String, Tag)*)(fa: F[A]): F[A] = fa
     def trace[A](operationName: String, parent: Span, tags: (String, Tag)*)(fa: F[A]): F[A] = fa
-    def trace[A](operationName: String, parent: Context, tags: (String, Tag)*)(fa: F[A]): F[A] = fa
+    def trace[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(fa: F[A]): F[A] = fa
     def traceWith[A](operationName: String, tags: (String, Tag)*)(fa: Span => F[(Span, A)]): F[A] =
-      fa(Span.noop).map(_._2)
+      fa(Span.empty).map(_._2)
     def traceWith[A](operationName: String, parent: Span, tags: (String, Tag)*)(fa: Span => F[(Span, A)]): F[A] =
-      fa(Span.noop).map(_._2)
-    def traceWith[A](operationName: String, parent: Context, tags: (String, Tag)*)(fa: Span => F[(Span, A)]): F[A] =
-      fa(Span.noop).map(_._2)
+      fa(Span.empty).map(_._2)
+    def traceWith[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(
+        fa: Span => F[(Span, A)]
+    ): F[A] =
+      fa(Span.empty).map(_._2)
   }
   // $COVERAGE-ON$
 
@@ -129,7 +131,7 @@ object Tracer {
       def trace[A](operationName: String, parent: Span, tags: (String, Tag)*)(fa: G[A]): G[A] =
         to(tracer.trace(operationName, parent, tags: _*)(from(fa)))
 
-      def trace[A](operationName: String, parent: Context, tags: (String, Tag)*)(fa: G[A]): G[A] =
+      def trace[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(fa: G[A]): G[A] =
         to(tracer.trace(operationName, parent, tags: _*)(from(fa)))
 
       def traceWith[A](operationName: String, tags: (String, Tag)*)(fa: Span => G[(Span, A)]): G[A] =
@@ -140,7 +142,7 @@ object Tracer {
       ): G[A] =
         to(tracer.traceWith(operationName, parent, tags: _*)(span => from(fa(span))))
 
-      def traceWith[A](operationName: String, parent: Context, tags: (String, Tag)*)(
+      def traceWith[A](operationName: String, parent: Option[Context], tags: (String, Tag)*)(
           fa: Span => G[(Span, A)]
       ): G[A] =
         to(tracer.traceWith(operationName, parent, tags: _*)(span => from(fa(span))))

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="skadi.svg" width="1100px" />  
   <br/>
-  <i>- The goddess of bowhunting & skiing that traces her prey through the winter of mountains</i>
+  <i>- The goddess of bowhunting & skiing that traces her prey through the mountains</i>
 </p>
 
 ----
@@ -12,6 +12,14 @@
 
 Skadi is an abstraction over [distributed tracing](https://opentracing.io/docs/overview/what-is-tracing/) that
 provides a unified functional API for various tracers with reasoning & usability in mind.
+
+- Compatible with any OpenTracing client library
+- Support of span tags & logs
+- Each effect is suspended within the polymorphic `F[_]`
+- Spans preserved within the context of `F[_]` don't pollute business API
+
+Library heavily relies on cats-effect type classes, and works with _any_ effect that could carry
+the context, such as `Kleisli`, `StateT`, `RWST`, `monix.Task` with `TaskLocal`, `ZIO` with `FiberRef`.
 
 # WIP
 

--- a/opentracing/src/main/scala/io/skadi/opentracing/IllegalSpanKind.scala
+++ b/opentracing/src/main/scala/io/skadi/opentracing/IllegalSpanKind.scala
@@ -1,3 +1,7 @@
 package io.skadi.opentracing
 
+/**
+  * This exception appears in case of API misuse such that provided `io.skadi.Span` was built outside of
+  * OpenTracing-based tracer
+  */
 case object IllegalSpanKind extends Exception("Illegal span kind. Expected to have an opentracing span")

--- a/opentracing/src/main/scala/io/skadi/opentracing/impl/OpentracingSpan.scala
+++ b/opentracing/src/main/scala/io/skadi/opentracing/impl/OpentracingSpan.scala
@@ -1,40 +1,15 @@
 package io.skadi.opentracing.impl
 
-import java.time.Instant
-
 import io.opentracing.{Span => OTSpan}
-import io.skadi.{Context, Span, Tag, TraceLog}
+import io.skadi.{Context, Span}
 
 private[skadi] case class OpentracingSpan(
-    name: String,
-    tags: Map[String, Tag],
-    exception: Option[Throwable] = None,
-    stopTime: Option[Instant] = None,
-    logs: List[TraceLog] = List.empty,
+    data: Span.Data,
     underlying: OTSpan
 ) extends Span { self =>
-
-  def withTag(name: String, tag: Tag): Span =
-    copy(tags = tags.updated(name, tag))
-
-  def withTags(tags: (String, Tag)*): Span =
-    copy(tags = this.tags ++ tags)
-
-  def withException(e: Throwable): Span =
-    copy(exception = Some(e))
-
-  def withName(name: String): Span =
-    copy(name = name)
-
-  def withStopTime(time: Instant): Span =
-    copy(stopTime = Some(time))
 
   def context: Context =
     OpentracingContext(underlying.context())
 
-  def withLog(traceLog: TraceLog): Span =
-    copy(logs = traceLog :: logs)
-
-  def withLogs(traceLogs: List[TraceLog]): Span =
-    copy(logs = traceLogs ::: logs)
+  def update(data: Span.Data): Span = copy(data = data)
 }

--- a/opentracing/src/main/scala/io/skadi/opentracing/impl/OpentracingTracer.scala
+++ b/opentracing/src/main/scala/io/skadi/opentracing/impl/OpentracingTracer.scala
@@ -49,8 +49,13 @@ private[skadi] class OpentracingTracer[F[_]: Trace](openTracer: OTracer)(implici
         }
 
         OpentracingSpan(
-          name = operationName,
-          tags = tags.toMap,
+          data = Span.Data(
+            name = operationName,
+            tags = tags.toMap,
+            logs = List.empty,
+            exception = None,
+            stopTime = None
+          ),
           underlying = withParent.ignoreActiveSpan().start()
         )
       }

--- a/tests/src/test/scala/io/skadi/Instances.scala
+++ b/tests/src/test/scala/io/skadi/Instances.scala
@@ -6,7 +6,7 @@ import cats.data.{Kleisli, StateT}
 import cats.effect.IO
 import cats.syntax.all._
 import cats.{Eq, FlatMap}
-import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalacheck.{Arbitrary, Gen}
 
 trait Instances {
 
@@ -19,12 +19,14 @@ trait Instances {
     exception <- Gen.option(Gen.const(new Exception()))
   } yield {
     TestSpan(
-      name = operationName,
-      tags = tags,
-      logs = logs,
-      exception = exception,
+      data = Span.Data(
+        name = operationName,
+        tags = tags,
+        logs = logs,
+        exception = exception,
+        stopTime = stopTime
+      ),
       startTime = startTime,
-      stopTime = stopTime,
       parent = None
     )
   }
@@ -53,11 +55,6 @@ trait Instances {
   }
 
   implicit val eqSpan: Eq[Span] = Eq.fromUniversalEquals
-
-  implicit val cogenSpan: Cogen[Span] = Cogen.cogenString.contramap {
-    case testSpan: TestSpan => testSpan.name
-    case _                  => throw new IllegalStateException("Unexpected span kind")
-  }
 
   implicit val arbitrarySpan: Arbitrary[Span] = Arbitrary(genSpan)
 

--- a/tests/src/test/scala/io/skadi/TestSpan.scala
+++ b/tests/src/test/scala/io/skadi/TestSpan.scala
@@ -1,32 +1,18 @@
 package io.skadi
+
 import java.time.Instant
 
 import io.skadi.TestSpan.TestContext
 
 case class TestSpan(
-    name: String,
-    tags: Map[String, Tag],
-    logs: List[TraceLog],
-    exception: Option[Throwable],
+    data: Span.Data,
     startTime: Instant,
-    stopTime: Option[Instant],
     parent: Option[TestContext]
 ) extends Span {
-  def withName(name: String): Span = copy(name = name)
-
-  def withTag(name: String, tag: Tag): Span = copy(tags = tags.updated(name, tag))
-
-  def withTags(tags: (String, Tag)*): Span = copy(tags = this.tags ++ tags)
-
-  def withLog(traceLog: TraceLog): Span = copy(logs = traceLog :: logs)
-
-  def withLogs(traceLogs: List[TraceLog]): Span = copy(logs = traceLogs ++ logs)
-
-  def withException(e: Throwable): Span = copy(exception = Some(e))
-
-  def withStopTime(time: Instant): Span = copy(stopTime = Some(time))
 
   def context: Context = TestSpan.TestContext(this, parent)
+  def update(data: Span.Data): Span = copy(data = data)
+
 }
 
 object TestSpan {

--- a/tests/src/test/scala/io/skadi/tracers/DefaultTracerSpec.scala
+++ b/tests/src/test/scala/io/skadi/tracers/DefaultTracerSpec.scala
@@ -130,12 +130,14 @@ class DefaultTracerSpec extends SkadiSpec {
           tags: Seq[(String, Tag)],
           startTime: Instant
       ): F[Span] = (TestSpan(
-        name = operationName,
-        tags = tags.toMap,
-        logs = List.empty,
-        exception = None,
+        data = Span.Data(
+          name = operationName,
+          tags = tags.toMap,
+          logs = List.empty,
+          exception = None,
+          stopTime = None
+        ),
         startTime = startTime,
-        stopTime = None,
         parent = parent.map(_.asInstanceOf[TestContext])
       ): Span).pure[F]
     }
@@ -151,12 +153,14 @@ class DefaultTracerSpec extends SkadiSpec {
           tags: Seq[(String, Tag)],
           startTime: Instant
       ): G[Span] = (TestSpan(
-        name = operationName,
-        tags = tags.toMap,
-        logs = List.empty,
-        exception = None,
+        data = Span.Data(
+          name = operationName,
+          tags = tags.toMap,
+          logs = List.empty,
+          exception = None,
+          stopTime = None
+        ),
         startTime = startTime,
-        stopTime = None,
         parent = parent.map(_.asInstanceOf[TestContext])
       ): Span).pure[G]
     }


### PR DESCRIPTION
- Move all the span data into `Span.Data`, so the implementations of `Span` interface would only need to take care of `context` & `update(Span.Data)` ﻿implementations
- `Tracer.trace` should accept optional context instead of required, as the `TraceCarrier` returns an optional one
- `SkadiOpentracing` builder returns `Tracer[F] with TraceCarrier[F, Map[String,String]]` instead of two separate instances, as it's easier to acquire it
